### PR TITLE
remove android:allowBackup="true"

### DIFF
--- a/FlowLayout/src/main/AndroidManifest.xml
+++ b/FlowLayout/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.wefika.flowlayout">
 
-    <application android:allowBackup="true" />
+    <application/>
 
 </manifest>


### PR DESCRIPTION
This is conflicting with `android:allowBackup` in the app manifest.

This error is shown:

```
Error:Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:16:9-36
    is also present at [com.wefika:flowlayout:0.4.0] AndroidManifest.xml:11:18-44 value=(true)
    Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:14:5-51:19 to override
```

Tested on N5 running Android M Preview 2.
