### PR TITLE
fix child width bug when remeasure child height

### DIFF
--- a/FlowLayout/src/main/java/com/wefika/flowlayout/FlowLayout.java
+++ b/FlowLayout/src/main/java/com/wefika/flowlayout/FlowLayout.java
@@ -275,7 +275,7 @@ public class FlowLayout extends ViewGroup {
 				// if height is match_parent we need to remeasure child to line height
 				if(lp.height == LayoutParams.MATCH_PARENT) {
 					int childWidthMode = MeasureSpec.AT_MOST;
-					int childWidthSize = lineWidth;
+					int childWidthSize = width - (lp.leftMargin + lp.rightMargin + getPaddingLeft() + getPaddingRight());
 
 					if(lp.width == LayoutParams.MATCH_PARENT) {
 						childWidthMode = MeasureSpec.EXACTLY;


### PR DESCRIPTION
when remeasure child height in `onLayout` method, the code `int childWidthSize = lineWidth` is a bug which will make  the following child wrong width. 
 `
<View 
     android:layout_height = "match_parent"  
     android:layout_width = "match_parent"/>
`
the actual width is the total width of last row.
